### PR TITLE
Define prettier as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,17 +9,20 @@
   },
   "dependencies": {
     "@typescript-eslint/typescript-estree": "^5.59.8",
-    "is-builtin-module": "^3.2.1",
-    "prettier": "^2.8.8"
+    "is-builtin-module": "^3.2.1"
   },
   "devDependencies": {
     "@types/jest": "^29.5.2",
     "@types/node": "^20.2.0",
     "@types/prettier": "^2.7.2",
     "jest": "^29.5.0",
+    "prettier": "^2.8.8",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.4"
+  },
+  "peerDependencies": {
+    "prettier": ">=2 || >=3"
   },
   "packageManager": "yarn@3.5.1",
   "directories": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -424,6 +424,8 @@ __metadata:
     ts-jest: ^29.1.0
     ts-node: ^10.9.1
     typescript: ^5.0.4
+  peerDependencies:
+    prettier: ">=2 || >=3"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This gives users more flexibility with the package version, and it doesn't really make sense to have this package if prettier isn't already a dependency.